### PR TITLE
Adjust Demo File & New Config Option

### DIFF
--- a/src/main/kotlin/com/illuzionzstudios/customfishing/reward/RewardController.kt
+++ b/src/main/kotlin/com/illuzionzstudios/customfishing/reward/RewardController.kt
@@ -26,7 +26,9 @@ object RewardController : PluginController {
             listOf("demo_reward.yml")
         ).loaders.forEach {
             loadedRewards.add(it.`object`)
-            Logger.info("Loading fishing reward '${it.`object`.name}'")
+            if (Settings.REWARD_STARTUP_LOG) {
+                Logger.info("Loading fishing reward '${it.`object`.name}'")
+            }
         }
     }
 

--- a/src/main/kotlin/com/illuzionzstudios/customfishing/settings/Settings.kt
+++ b/src/main/kotlin/com/illuzionzstudios/customfishing/settings/Settings.kt
@@ -43,5 +43,12 @@ class Settings(plugin: SpigotPlugin) : PluginSettings(plugin) {
             "The maximum amount of ticks to wait for a bite. This is before processing lure and other things",
             "REQUIRES 1.16+"
         )
+
+        var REWARD_STARTUP_LOG: ConfigSetting = GENERAL_GROUP.create(
+            "fishing.reward-startup-log",
+            true,
+            "Set to \"false\" to disable the server from showing all rewards that are successfully loaded on startup",
+            "set to \"true\" by default"
+        )
     }
 }

--- a/src/main/kotlin/com/illuzionzstudios/customfishing/settings/Settings.kt
+++ b/src/main/kotlin/com/illuzionzstudios/customfishing/settings/Settings.kt
@@ -47,8 +47,8 @@ class Settings(plugin: SpigotPlugin) : PluginSettings(plugin) {
         var REWARD_STARTUP_LOG: ConfigSetting = GENERAL_GROUP.create(
             "fishing.reward-startup-log",
             true,
-            "Set to \"false\" to disable the server from showing all rewards that are successfully loaded on startup",
-            "set to \"true\" by default"
+            "Set to \"false\" to disable the server from showing all rewards that are successfully loaded on console",
+            "Set to \"true\" by default"
         )
     }
 }

--- a/src/main/resources/rewards/demo_reward.yml
+++ b/src/main/resources/rewards/demo_reward.yml
@@ -74,9 +74,8 @@ weight: 4.5
 # If set to false only the custom reward will be given
 vanilla-rewards: false
 
-# The amount of experience to give the player
-# as a range, the "x to y" meaning from x to y (inclusive)
-# Can just be a singular number
+# The amount of experience to give the player as a range.
+# "x to y" means from x to y (inclusive) or [x,y]
 exp-amount: "1 to 6"
 
 # The sound to play when this reward is caught. Leave blank


### PR DESCRIPTION
After debugging my rewards I realized finally that the issue as to why the rewards were not loading was because my exp-amounts were in single numbers instead of ranges. To further clear this confusion up, I've removed it from the demo file if someone say wants 1 exp can do "1 to 1" to get 1 exp.

Also added a new fishing configuration option that would hide all the successfully loaded rewards if it's disabled. ( #9 )